### PR TITLE
Always use go tar libraries on windows

### DIFF
--- a/tarfs/compress.go
+++ b/tarfs/compress.go
@@ -6,11 +6,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 func Compress(dest io.Writer, workDir string, paths ...string) error {
-	if tarPath, err := exec.LookPath("tar"); err == nil {
-		return tarCompress(tarPath, dest, workDir, paths...)
+	if runtime.GOOS != "windows" {
+		if tarPath, err := exec.LookPath("tar"); err == nil {
+			return tarCompress(tarPath, dest, workDir, paths...)
+		}
 	}
 
 	absWorkDir, err := filepath.Abs(workDir)

--- a/tarfs/compress_test.go
+++ b/tarfs/compress_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/concourse/go-archive/tarfs"
 	. "github.com/onsi/ginkgo"
@@ -31,6 +32,7 @@ var _ = Describe("Compress", func() {
 
 		innerFile, err := os.Create(filepath.Join(dir, "outer-dir", "inner-dir", "some-file"))
 		Expect(err).NotTo(HaveOccurred())
+		defer innerFile.Close()
 
 		_, err = innerFile.Write([]byte("sup"))
 		Expect(err).NotTo(HaveOccurred())
@@ -108,6 +110,9 @@ var _ = Describe("Compress", func() {
 
 	Context("with tar in the PATH", func() {
 		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("use go archive library only for windows")
+			}
 			_, err := exec.LookPath("tar")
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/tarfs/extract.go
+++ b/tarfs/extract.go
@@ -6,12 +6,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 func Extract(src io.Reader, dest string) error {
-	tarPath, err := exec.LookPath("tar")
-	if err == nil {
-		return tarExtract(tarPath, src, dest)
+	if runtime.GOOS != "windows" {
+		tarPath, err := exec.LookPath("tar")
+		if err == nil {
+			return tarExtract(tarPath, src, dest)
+		}
 	}
 
 	tarReader := tar.NewReader(src)

--- a/tarfs/extract_test.go
+++ b/tarfs/extract_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/concourse/go-archive/archivetest"
 	"github.com/concourse/go-archive/tarfs"
@@ -84,7 +85,9 @@ var _ = Describe("Extract", func() {
 
 		executableInfo, err := executable.Stat()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(executableInfo.Mode()).To(Equal(os.FileMode(0644)))
+		if runtime.GOOS != "windows" {
+			Expect(executableInfo.Mode()).To(Equal(os.FileMode(0644)))
+		}
 
 		emptyDir, err := os.Open(filepath.Join(extractionDest, "empty-dir"))
 		Expect(err).NotTo(HaveOccurred())
@@ -101,11 +104,16 @@ var _ = Describe("Extract", func() {
 		symlinkInfo, err := os.Lstat(filepath.Join(extractionDest, "some-symlink"))
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(symlinkInfo.Mode() & 0755).To(Equal(os.FileMode(0755)))
+		if runtime.GOOS != "windows" {
+			Expect(symlinkInfo.Mode() & 0755).To(Equal(os.FileMode(0755)))
+		}
 	}
 
 	Context("when 'tar' is on the PATH", func() {
 		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("use go archive library only for windows")
+			}
 			_, err := exec.LookPath("tar")
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/tgzfs/compress.go
+++ b/tgzfs/compress.go
@@ -7,11 +7,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 func Compress(dest io.Writer, workDir string, paths ...string) error {
-	if tarPath, err := exec.LookPath("tar"); err == nil {
-		return tarCompress(tarPath, dest, workDir, paths...)
+	if runtime.GOOS != "windows" {
+		if tarPath, err := exec.LookPath("tar"); err == nil {
+			return tarCompress(tarPath, dest, workDir, paths...)
+		}
 	}
 
 	absWorkDir, err := filepath.Abs(workDir)

--- a/tgzfs/compress_test.go
+++ b/tgzfs/compress_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/concourse/go-archive/tgzfs"
 	. "github.com/onsi/ginkgo"
@@ -112,6 +113,9 @@ var _ = Describe("Compress", func() {
 
 	Context("with tar in the PATH", func() {
 		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("use go archive library only for windows")
+			}
 			_, err := exec.LookPath("tar")
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/tgzfs/extract.go
+++ b/tgzfs/extract.go
@@ -7,12 +7,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 func Extract(src io.Reader, dest string) error {
-	tarPath, err := exec.LookPath("tar")
-	if err == nil {
-		return tarExtract(tarPath, src, dest)
+	if runtime.GOOS != "windows" {
+		tarPath, err := exec.LookPath("tar")
+		if err == nil {
+			return tarExtract(tarPath, src, dest)
+		}
 	}
 
 	gr, err := gzip.NewReader(src)

--- a/tgzfs/extract_test.go
+++ b/tgzfs/extract_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/concourse/go-archive/archivetest"
 	"github.com/concourse/go-archive/tgzfs"
@@ -84,7 +85,9 @@ var _ = Describe("Extract", func() {
 
 		executableInfo, err := executable.Stat()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(executableInfo.Mode()).To(Equal(os.FileMode(0644)))
+		if runtime.GOOS != "windows" {
+			Expect(executableInfo.Mode()).To(Equal(os.FileMode(0644)))
+		}
 
 		emptyDir, err := os.Open(filepath.Join(extractionDest, "empty-dir"))
 		Expect(err).NotTo(HaveOccurred())
@@ -101,11 +104,16 @@ var _ = Describe("Extract", func() {
 		symlinkInfo, err := os.Lstat(filepath.Join(extractionDest, "some-symlink"))
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(symlinkInfo.Mode() & 0755).To(Equal(os.FileMode(0755)))
+		if runtime.GOOS != "windows" {
+			Expect(symlinkInfo.Mode() & 0755).To(Equal(os.FileMode(0755)))
+		}
 	}
 
 	Context("when 'tar' is on the PATH", func() {
 		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("use go archive library only for windows")
+			}
 			_, err := exec.LookPath("tar")
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/zipfs/extract_test.go
+++ b/zipfs/extract_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/concourse/go-archive/archivetest"
 	"github.com/concourse/go-archive/zipfs"
@@ -84,7 +85,9 @@ var _ = Describe("Extract", func() {
 
 		executableInfo, err := executable.Stat()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(executableInfo.Mode()).To(Equal(os.FileMode(0644)))
+		if runtime.GOOS != "windows" {
+			Expect(executableInfo.Mode()).To(Equal(os.FileMode(0644)))
+		}
 
 		emptyDir, err := os.Open(filepath.Join(extractionDest, "empty-dir"))
 		Expect(err).NotTo(HaveOccurred())
@@ -101,11 +104,16 @@ var _ = Describe("Extract", func() {
 		symlinkInfo, err := os.Lstat(filepath.Join(extractionDest, "some-symlink"))
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(symlinkInfo.Mode() & 0755).To(Equal(os.FileMode(0755)))
+		if runtime.GOOS != "windows" {
+			Expect(symlinkInfo.Mode() & 0755).To(Equal(os.FileMode(0755)))
+		}
 	}
 
 	Context("when 'unzip' is on the PATH", func() {
 		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("unzip is not valid on Windows")
+			}
 			_, err := exec.LookPath("unzip")
 			Expect(err).NotTo(HaveOccurred())
 		})


### PR DESCRIPTION
On the latest versions of Window Server 2016 (1803) and Windows Server 2019, there is a `tar` executable that is shipped in the OS image. This `tar` executable behaves more or less the same way as the BSD tar that has been shipped with the current version of Windows stemcells, but this behavior does not function properly when Houdini streams in resources into Windows workers. We fixed the problem in concourse-windows-release by removing the system `tar` from the `PATH`: https://github.com/pivotal-cf-experimental/concourse-windows-worker-release/pull/5. We think one possible fix would be to always use the standard go library for tar operations.